### PR TITLE
Adding fallback type; new fallback description in ISDA Supplement 70

### DIFF
--- a/src/main/java/marc/henrard/murisq/product/generic/FallbackType.java
+++ b/src/main/java/marc/henrard/murisq/product/generic/FallbackType.java
@@ -42,7 +42,13 @@ public enum FallbackType implements NamedEnum {
    * The Compounded Setting in Arrears Rate, with start accrual date shifted 2 business days and period 
    * based on Ibor tenor. As published in Bloomberg IBOR fallback rule book.
    */
-  COMPOUNDED_IN_ARREARS_2DAYS_TENOR;
+  COMPOUNDED_IN_ARREARS_2DAYS_TENOR,
+  /**
+   * The Compounded Setting in Arrears Rate, with start accrual date shifted 2 business days and period 
+   * based on Ibor tenor. As published in Bloomberg IBOR fallback rule book. With the extra requirement
+   * that the last rate published two business days preceding the related payment date is used.
+   */
+  COMPOUNDED_IN_ARREARS_2DAYS_TENOR_2DAYS_PAYMENT;
 
   private static final EnumNames<FallbackType> NAMES = EnumNames.of(FallbackType.class);
 

--- a/src/test/java/marc/henrard/murisq/model/lmm/LmmdddSwaptionRootBachelierVolatility2SkewCalibratorTest.java
+++ b/src/test/java/marc/henrard/murisq/model/lmm/LmmdddSwaptionRootBachelierVolatility2SkewCalibratorTest.java
@@ -101,6 +101,7 @@ public class LmmdddSwaptionRootBachelierVolatility2SkewCalibratorTest {
       LmmdddSwaptionRootBachelierVolatility2SkewCalibrator.of(LMM_1F_START);
   private static final LmmdddSwaptionRootBachelierVolatility2SkewCalibrator LMM1_CALIBRATOR_2F =
       LmmdddSwaptionRootBachelierVolatility2SkewCalibrator.of(LMM_2F_START);
+  
   private static final Offset<Double> TOLERANCE_APPROX_IV = within(1.0E-8);
   private static final boolean PRINT_DETAILS = false;
 

--- a/src/test/java/marc/henrard/murisq/pricer/cms/LmmdddCmsPeriodMonteCarloPricerTest.java
+++ b/src/test/java/marc/henrard/murisq/pricer/cms/LmmdddCmsPeriodMonteCarloPricerTest.java
@@ -134,6 +134,7 @@ public class LmmdddCmsPeriodMonteCarloPricerTest {
   private static final Offset<Double> TOLERANCE_DF = within(1.0E-12);
   private static final Offset<Double> TOLERANCE_RATE = within(1.0E-12);
   private static final Offset<Double> TOLERANCE_PV_EXACT = within(1.0E-12);
+  private static final boolean PRINT_DETAILS = false;
   
   /* Multi-curve equivalent, only one case */
   @Test
@@ -389,8 +390,8 @@ public class LmmdddCmsPeriodMonteCarloPricerTest {
   public void comparison_hw() {
     Offset<Double> toleranceRate = within(7.5E-4);
     int nbPaths = 10_000;
-//    long start, end;
-//    start = System.currentTimeMillis();
+    long start, end;
+    start = System.currentTimeMillis();
     // nbPaths/error 10,000: ~7.5E-4 / 100,000: ~3.0E-4 (90s) / 500,000: ~2.3E-4 (428s) / 1,000,000: ~2.0E-4 (748s)
     DayCount dayCountHw = DayCounts.ACT_365F;
     HullWhiteOneFactorPiecewiseConstantParameters parametersHw =
@@ -425,8 +426,10 @@ public class LmmdddCmsPeriodMonteCarloPricerTest {
                   PRICER_CMS_HW.presentValue(CMS_PERIODS[looptype][loopindex][loopexp][looplag][loopstrike],
                       MULTICURVE_EUR, providerHw);
               double fwdHw = pvHw.getAmount() / (period.getNotional() * period.getYearFraction());
-//              System.out.println(INDICES[loopindex] + EXPIRIES[loopexp].toString() + TYPES[looptype] +
-//                  PAYMENT_LAG[looplag] + STRIKES[loopstrike] + ", " + fwdLmm + ", " + fwdHw + ", " + (fwdHw - fwdLmm));
+              if(PRINT_DETAILS) {
+              System.out.println(INDICES[loopindex] + EXPIRIES[loopexp].toString() + TYPES[looptype] +
+                  PAYMENT_LAG[looplag] + STRIKES[loopstrike] + ", " + fwdLmm + ", " + fwdHw + ", " + (fwdHw - fwdLmm));
+              }
               assertThat(fwdLmm).isEqualTo(fwdHw, toleranceRate); // Compare forward rates
               maxError = Math.max(Math.abs(fwdLmm - fwdHw), maxError);
             }
@@ -434,8 +437,10 @@ public class LmmdddCmsPeriodMonteCarloPricerTest {
         }
       }
     }
-//    end = System.currentTimeMillis();
-//    System.out.println("Paths: " + nbPaths + " in " + (end - start) + " ms. Max error: " + maxError);
+    end = System.currentTimeMillis();
+    if(PRINT_DETAILS) {
+    System.out.println("Paths: " + nbPaths + " in " + (end - start) + " ms. Max error: " + maxError);
+    }
   }
   
   private static LiborMarketModelDisplacedDiffusionDeterministicSpreadParameters lmmHw(ResolvedSwap swap) {

--- a/src/test/java/marc/henrard/murisq/product/generic/FallbackTypeTest.java
+++ b/src/test/java/marc/henrard/murisq/product/generic/FallbackTypeTest.java
@@ -29,6 +29,7 @@ public class FallbackTypeTest {
         {FallbackType.COMPOUNDED_IN_ARREARS_2DAYS_CALCPERIOD, "CompoundedInArrears2daysCalcperiod"},
         {FallbackType.COMPOUNDED_IN_ARREARS_2DAYS_IBORPERIOD, "CompoundedInArrears2daysIborperiod"},
         {FallbackType.COMPOUNDED_IN_ARREARS_2DAYS_TENOR, "CompoundedInArrears2daysTenor"},
+        {FallbackType.COMPOUNDED_IN_ARREARS_2DAYS_TENOR_2DAYS_PAYMENT, "CompoundedInArrears2daysTenor2daysPayment"},
     };
   }
 


### PR DESCRIPTION
Adding new fallback type. Correspond to the different fallback approach introduced in ISDA Supplement 70. This is different from the approaches described in the different consultations and in Bloomberg Rule Book by introducing an extra 2 business day requirement for before payment date for fallback observation date.