### PR TITLE
Overnight futures pricer

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Curve description as the multiplication of two underlying curves. Used for intra
 ### 3. Collateral cheapest-to-deliver
 Curve construction with intrinsic value of the cheapest-to-deliver. Option time value is not incorporated in this implementation. The construction provided the curve itself and the Jacobian to the underlying curves.
 
+### 4. Cash flow equivalent
+Extend the Strata calculator to cover overnight compounded in arrears payments.
+
 ## Models
 
 ### 1. Bachelier Formula
@@ -70,6 +73,7 @@ Explicit formula for implicit volatility.
 * Pricing of compounded overnight futures. Reference: Henrard, Marc. (2018) Overnight based futures: convexity adjustment estimation. Available at (https://ssrn.com/abstract=3134346).
 * Different formulas for cross-terms: same model parameters (Asian options) or different model parameters (discounting transition)
 * Pricing of CMS coupons/caplets/floorlets by efficient approximation.
+* Pricing of Swaption with Par Yield cash settlement using an efficient (third order) approximation.
 
 ### 3. G2++
 
@@ -152,6 +156,7 @@ Some recent public courses:
 * Workshop *Benchmarks in transition: Quantitative perspective on benchmarks, transition, fallback and regulation.*. Interest Rate Reform Conference (A Quant Perspective) - WBS (London, UK), 4 March 2020.
 * Workshop *Interest Rate Modelling in the Multi-curve Framework: Collateral and Regulatory Requirements*. LFS Workshop (London, UK), May 2020 and June 2020.
 * Course *Martingales and Fixed Income Valuation, CQF Module 5*. CQF Institute (London, UK), May 2020 and November 2020.
+* Planned: Workshop on *Benchmarks in transition*. CQF Institute (London, UK), May 2021.
 * Multiple in-house courses for commercial banks, central banks, hedge funds, international financial organisations, etc. We have provided public and in-house workshops/courses/seminars in Africa, America, Asia, Europe, and Oceania (special discount for any client base in Antarctica!). 
 
 ## Advisory

--- a/src/main/java/marc/henrard/murisq/pricer/indexfutures/HullWhiteOneFactorOvernightFuturesProductPricer.java
+++ b/src/main/java/marc/henrard/murisq/pricer/indexfutures/HullWhiteOneFactorOvernightFuturesProductPricer.java
@@ -1,0 +1,153 @@
+package marc.henrard.murisq.pricer.indexfutures;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.date.HolidayCalendar;
+import com.opengamma.strata.pricer.model.HullWhiteOneFactorPiecewiseConstantParametersProvider;
+import com.opengamma.strata.pricer.rate.RatesProvider;
+import com.opengamma.strata.product.index.ResolvedOvernightFuture;
+
+import marc.henrard.murisq.model.hullwhite.HullWhiteOneFactorPiecewiseConstantFormulas;
+
+/**
+ * Pricer of overnight futures on compounded in arrears rates in the Hull-White one-factor model.
+ * <p>
+ * <i>Reference: </i>
+ * <p>
+ * Henrard, Marc. (2018) Overnight based futures: convexity adjustment estimation
+ * 
+ * @author Marc Henrard
+ */
+public class HullWhiteOneFactorOvernightFuturesProductPricer {
+
+  /**
+   * Default implementation.
+   */
+  public static final HullWhiteOneFactorOvernightFuturesProductPricer DEFAULT = 
+      new HullWhiteOneFactorOvernightFuturesProductPricer();
+
+  /** The model related formulas. */
+  private static final HullWhiteOneFactorPiecewiseConstantFormulas FORMULAS =
+      HullWhiteOneFactorPiecewiseConstantFormulas.DEFAULT;
+
+  /**
+   * Returns the price of the overnight futures.
+   * 
+   * @param futures  the overnight futures
+   * @param multicurve  the multi-curve
+   * @param hwProvider  the Hull-White one-factor parameters provider
+   * @return  the price
+   */
+  public double price(
+      ResolvedOvernightFuture futures,
+      RatesProvider ratesProvider,
+      HullWhiteOneFactorPiecewiseConstantParametersProvider hwProvider) {
+
+    Currency ccy = futures.getCurrency();
+    List<LocalDate> onDates = overnightDates(futures);
+    LocalDate startDate = futures.getOvernightRate().getStartDate();
+    LocalDate endDate = futures.getOvernightRate().getEndDate();
+    int nbOnDates = onDates.size();
+    double delta = futures.getIndex().getDayCount()
+        .yearFraction(startDate, endDate); // index AF
+    double PcTs = ratesProvider.discountFactor(ccy, startDate);
+    double PcTe = ratesProvider.discountFactor(ccy, endDate);
+    List<Double> ti = new ArrayList<>();
+    ti.add(0.0d);
+    for (int i = 0; i < nbOnDates; i++) {
+      ti.add(hwProvider.relativeTime(onDates.get(i)));
+    }
+    List<Double> gamma = new ArrayList<>();
+    for (int i = 0; i < nbOnDates - 1; i++) {
+      gamma.add(FORMULAS.futuresConvexityFactor(
+          hwProvider.getParameters(), ti.get(i), ti.get(i + 1), ti.get(i + 1), ti.get(nbOnDates)));
+    }
+    double productGamma = 1.0;
+    for (int i = 0; i < onDates.size() - 1; i++) {
+      productGamma *= gamma.get(i);
+    }
+    return 1.0d - (PcTs / PcTe * productGamma - 1.0d) / delta;
+  }
+  
+  /**
+   * Returns the convexity adjustment associated to the overnight futures.
+   * 
+   * @param futures  the overnight futures
+   * @param multicurve  the multi-curve
+   * @param hwProvider  the Hull-White one-factor parameters provider
+   * @return  the adjustment
+   */
+  public double convexityAdjustment(
+      ResolvedOvernightFuture futures,
+      RatesProvider multicurve,
+      HullWhiteOneFactorPiecewiseConstantParametersProvider hwProvider) {
+
+    Currency ccy = futures.getCurrency();
+    List<Double> gamma = convexityAdjustmentGammas(futures, multicurve, hwProvider);
+    double productGamma = 1.0;
+    for (int i = 0; i < gamma.size() - 1; i++) {
+      productGamma *= gamma.get(i);
+    }
+    LocalDate startDate = futures.getOvernightRate().getStartDate();
+    LocalDate endDate = futures.getOvernightRate().getEndDate();
+    double delta = futures.getIndex().getDayCount().yearFraction(startDate, endDate);
+    double PcTs = multicurve.discountFactor(ccy, startDate);
+    double PcTe = multicurve.discountFactor(ccy, endDate);
+    return PcTs / PcTe * (productGamma - 1.0d) / delta;
+  }
+  
+  /**
+   * Returns the different gamma factors used in the convexity adjustment associated to the overnight futures.
+   * <p>
+   * See the literature reference for the exact definition of the factors.
+   * 
+   * @param futures  the overnight futures
+   * @param multicurve  the multi-curve
+   * @param hwProvider  the Hull-White one-factor parameters provider
+   * @return  the factors
+   */
+  public List<Double> convexityAdjustmentGammas(
+      ResolvedOvernightFuture futures,
+      RatesProvider multicurve,
+      HullWhiteOneFactorPiecewiseConstantParametersProvider hwProvider) {
+
+    List<LocalDate> onDates = overnightDates(futures);
+    int nbOnDates = onDates.size();
+    List<Double> ti = new ArrayList<>();
+    ti.add(0.0d);
+    for (int i = 0; i < nbOnDates; i++) {
+      ti.add(hwProvider.relativeTime(onDates.get(i)));
+    }
+    List<Double> gamma = new ArrayList<>();
+    for (int i = 0; i < nbOnDates - 1; i++) {
+      gamma.add(FORMULAS.futuresConvexityFactor(
+          hwProvider.getParameters(), ti.get(i), ti.get(i + 1), ti.get(i + 1), ti.get(nbOnDates)));
+    }
+    return gamma;
+  }
+  
+  /**
+   * Returns the overnight dates associated to a given futures.
+   * 
+   * @param futures  the overnight futures
+   * @return the dates
+   */
+  public List<LocalDate> overnightDates(ResolvedOvernightFuture futures){
+    
+    LocalDate startDate = futures.getOvernightRate().getStartDate();
+    LocalDate endDate = futures.getOvernightRate().getEndDate();
+    HolidayCalendar calendar = futures.getOvernightRate().getFixingCalendar();
+    List<LocalDate> onDates = new ArrayList<>();
+    LocalDate currentDate = startDate;
+    onDates.add(startDate);
+    while(currentDate.isBefore(endDate)) {
+      currentDate = calendar.next(currentDate);
+      onDates.add(currentDate);
+    }
+    return onDates;
+  }
+
+}

--- a/src/test/java/marc/henrard/murisq/pricer/indexfutures/HullWhiteOneFactorOvernightFuturesProductPricerTest.java
+++ b/src/test/java/marc/henrard/murisq/pricer/indexfutures/HullWhiteOneFactorOvernightFuturesProductPricerTest.java
@@ -1,0 +1,152 @@
+/**
+ * Copyright (C) 2021 - present by Marc Henrard.
+ */
+package marc.henrard.murisq.pricer.indexfutures;
+
+import static com.opengamma.strata.basics.currency.Currency.GBP;
+import static com.opengamma.strata.basics.index.OvernightIndices.GBP_SONIA;
+import static org.testng.Assert.assertEquals;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+
+import com.opengamma.strata.basics.ReferenceData;
+import com.opengamma.strata.basics.StandardId;
+import com.opengamma.strata.basics.currency.Currency;
+import com.opengamma.strata.basics.date.DayCounts;
+import com.opengamma.strata.basics.date.HolidayCalendar;
+import com.opengamma.strata.basics.index.OvernightIndex;
+import com.opengamma.strata.basics.index.OvernightIndexObservation;
+import com.opengamma.strata.basics.value.Rounding;
+import com.opengamma.strata.collect.array.DoubleArray;
+import com.opengamma.strata.pricer.model.HullWhiteOneFactorPiecewiseConstantParameters;
+import com.opengamma.strata.pricer.model.HullWhiteOneFactorPiecewiseConstantParametersProvider;
+import com.opengamma.strata.pricer.rate.ImmutableRatesProvider;
+import com.opengamma.strata.product.SecurityId;
+import com.opengamma.strata.product.index.ResolvedOvernightFuture;
+import com.opengamma.strata.product.rate.OvernightRateComputation;
+import com.opengamma.strata.product.swap.OvernightAccrualMethod;
+
+import marc.henrard.murisq.dataset.MulticurveStandardGbpDataSet;
+import marc.henrard.murisq.model.hullwhite.HullWhiteOneFactorPiecewiseConstantFormulas;
+
+/**
+ * Tests {@link HullWhiteOneFactorOvernightFuturesProductPricer}
+ * 
+ * @author Marc Henrard
+ */
+public class HullWhiteOneFactorOvernightFuturesProductPricerTest {
+
+  private static final ReferenceData REF_DATA = ReferenceData.standard();
+  private static final LocalDate VALUATION_DATE = LocalDate.of(2017, 12, 29);
+  private static final LocalTime VALUATION_TIME = LocalTime.of(11, 0);
+  private static final ZoneId VALUATION_ZONE = ZoneId.of("Europe/London");
+
+  public static final ImmutableRatesProvider MULTICURVE =
+      MulticurveStandardGbpDataSet.multicurve(VALUATION_DATE, REF_DATA);
+  
+  private static final double MEAN_REVERSION = 0.03;
+  private static final DoubleArray VOLATILITY = DoubleArray.of(0.0065);
+  private static final DoubleArray VOLATILITY_TIME = DoubleArray.of();
+  private static final HullWhiteOneFactorPiecewiseConstantParameters HW_PARAMETERS =
+      HullWhiteOneFactorPiecewiseConstantParameters.of(MEAN_REVERSION, VOLATILITY, VOLATILITY_TIME);
+  private static final HullWhiteOneFactorPiecewiseConstantParametersProvider HW_PROVIDER =
+      HullWhiteOneFactorPiecewiseConstantParametersProvider.of(HW_PARAMETERS, DayCounts.ACT_365F, 
+          VALUATION_DATE, VALUATION_TIME, VALUATION_ZONE);
+  private static final HullWhiteOneFactorPiecewiseConstantFormulas FORMULAS =
+      HullWhiteOneFactorPiecewiseConstantFormulas.DEFAULT;
+  
+  private static final HullWhiteOneFactorOvernightFuturesProductPricer PRICER_FUT =
+      HullWhiteOneFactorOvernightFuturesProductPricer.DEFAULT;
+
+  private static final SecurityId ID = SecurityId.of(StandardId.of("muRisQ", "Fut"));
+  private static final double NOTIONAL = 500_000;
+  private static final LocalDate START_ACCRUAL_DATE = LocalDate.of(2021, 6, 16);
+  private static final LocalDate END_ACCRUAL_DATE = LocalDate.of(2021, 9, 15);
+  private static final OvernightIndex INDEX = GBP_SONIA;
+  
+  private static final ResolvedOvernightFuture ON_FUTURES = ResolvedOvernightFuture.builder()
+      .accrualFactor(0.25)
+      .currency(GBP)
+      .lastTradeDate(START_ACCRUAL_DATE)
+      .notional(NOTIONAL)
+      .overnightRate(OvernightRateComputation
+          .of(INDEX, START_ACCRUAL_DATE, END_ACCRUAL_DATE, 0, OvernightAccrualMethod.COMPOUNDED, REF_DATA))
+      .securityId(ID)
+      .rounding(Rounding.none())
+      .build();
+  
+  private static final double TOLERANCE_GAMMA = 1.0E-8;
+  private static final double TOLERANCE_PRICE = 1.0E-8;
+
+  /* Tests gamma factors v local implementation */
+  @Test
+  public void gammas() {
+    List<LocalDate> onDates = PRICER_FUT.overnightDates(ON_FUTURES);
+    int nbOnDates = onDates.size();
+    List<Double> gammasComputed = PRICER_FUT.convexityAdjustmentGammas(ON_FUTURES, MULTICURVE, HW_PROVIDER);
+    assertEquals(gammasComputed.size(), nbOnDates - 1);
+    List<Double> ti = new ArrayList<>();
+    ti.add(0.0d);
+    for (int i = 0; i < nbOnDates; i++) {
+      ti.add(HW_PROVIDER.relativeTime(onDates.get(i)));
+    }
+    for (int i = 0; i < nbOnDates - 1; i++) {
+      double gammaExpected = FORMULAS.futuresConvexityFactor(
+          HW_PROVIDER.getParameters(), ti.get(i), ti.get(i + 1), ti.get(i + 1), ti.get(nbOnDates));
+      assertEquals(gammasComputed.get(i), gammaExpected, TOLERANCE_GAMMA);
+    }
+  }
+
+  /* Tests convexity v local implementation */
+  @Test
+  public void convexityAdjustment() {
+    List<Double> gammas = PRICER_FUT.convexityAdjustmentGammas(ON_FUTURES, MULTICURVE, HW_PROVIDER);
+    Currency ccy = GBP_SONIA.getCurrency();
+    double delta = GBP_SONIA.getDayCount().yearFraction(START_ACCRUAL_DATE, END_ACCRUAL_DATE);
+    double PcTs = MULTICURVE.discountFactor(ccy, START_ACCRUAL_DATE);
+    double PcTe = MULTICURVE.discountFactor(ccy, END_ACCRUAL_DATE);
+    double productGamma = 1.0;
+    for (int i = 0; i < gammas.size(); i++) {
+      productGamma *= gammas.get(i);
+    }
+    double caExpected = PcTs / PcTe * (productGamma - 1.0d) / delta;
+    double caComputed = PRICER_FUT.convexityAdjustment(ON_FUTURES, MULTICURVE, HW_PROVIDER);
+    assertEquals(caComputed, caExpected, TOLERANCE_PRICE);
+  }
+
+  /* Tests price v local implementation */
+  @Test
+  public void price() {
+    double adj = PRICER_FUT.convexityAdjustment(ON_FUTURES, MULTICURVE, HW_PROVIDER);
+    double fwd = MULTICURVE.overnightIndexRates(INDEX)
+        .periodRate(OvernightIndexObservation.of(INDEX, START_ACCRUAL_DATE, REF_DATA), END_ACCRUAL_DATE);
+    double priceExpected = 1 - (fwd + adj);
+    double priceComputed = PRICER_FUT.price(ON_FUTURES, MULTICURVE, HW_PROVIDER);
+    assertEquals(priceComputed, priceExpected, TOLERANCE_PRICE);
+  }
+
+  /* Tests overnight dates */
+  @Test
+  public void onDates() {
+    List<LocalDate> onDatesComputed = PRICER_FUT.overnightDates(ON_FUTURES);
+    HolidayCalendar calendar = REF_DATA.getValue(GBP_SONIA.getFixingCalendar());
+    List<LocalDate> onDatesExpected = new ArrayList<>();
+    LocalDate currentDate = START_ACCRUAL_DATE;
+    onDatesExpected.add(currentDate);
+    while (currentDate.isBefore(END_ACCRUAL_DATE)) {
+      currentDate = calendar.next(currentDate);
+      onDatesExpected.add(currentDate);
+    }
+    assertEquals(onDatesComputed.size(), onDatesExpected.size());
+    for (int i = 0; i < onDatesComputed.size(); i++) {
+      assertEquals(onDatesComputed.get(i), onDatesExpected.get(i));
+    }
+  }
+
+}


### PR DESCRIPTION
Duplicate the pricer for overnight futures to apply to the Strata product description.
The local description of the "compounded" futures will be removed in a subsequent version.